### PR TITLE
Added chai.expect require to test example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ on) will then be available for use.
 
 ```js
 var jsdom = require('mocha-jsdom');
+var expect = require('chai').expect;
 
 describe('mocha tests', function () {
 


### PR DESCRIPTION
It's necessary to require `require('chai').expect` to examples similar at `mocha-jsdom/test/simple.js`. 
Regards.