### PR TITLE
Upgraded 'jsdom' version to '3.1.2'

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "^1.9.1",
     "coveralls": "^2.11.2",
     "jquery": "^2.1.1",
-    "jsdom": "^1.0.0-pre.7",
+    "jsdom": "^3.1.2",
     "mocha": "^1.21.4",
     "mocha-clean": "^0.2.0",
     "mocha-lcov-reporter": "0.0.1"


### PR DESCRIPTION
Upgraded 'jsdom' version. Initial version of jsdom gave error 'TypeError: needs a
"context" arguement'.
Refer the issue https://github.com/rstacruz/mocha-jsdom/issues/3. 
