### PR TITLE
Initialize global.window when it is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = function (_options) {
     for (var key in window) {
       if (!window.hasOwnProperty(key)) continue
       if (~blacklist.indexOf(key)) continue
-      if (key in global) {
+      if (global[key]) {
         if (process.env.JSDOM_VERBOSE) {
           console.warn("[jsdom] Warning: skipping cleanup of global['" + key + "']")
         }

--- a/test/robust.js
+++ b/test/robust.js
@@ -1,0 +1,16 @@
+/* global it, before, window, describe, expect */
+
+var jsdom = require('../index')
+
+describe('robust', function () {
+  before(function () {
+    // User or another test framework redefines global.window
+    global.window = undefined
+  })
+
+  jsdom()
+
+  it('has window', function () {
+    expect(global.window).to.not.be.undefined
+  })
+})


### PR DESCRIPTION
Hi Rico,

This PR fixes an edge case I encountered where another test framework stubbed `global.window` but didn't fully clean up (called `global.window = undefined` instead of `delete global.window`). This caused mocha-jsdom to skip the recreation of `global.window` because `'window' in global === true`. 

Thanks for creating mocha-jsdom. It's been very useful as part of [airbnb/enzyme](https://github.com/airbnb/enzyme).