### PR TITLE
Add jsdom as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,14 @@ See [examples/basic](examples/basic/) for a setup that allows for testing via io
 
 ## Thanks
 
-**mocha-jsdom** © 2014+, Rico Sta. Cruz. Released under the [MIT] License.<br>
-Authored and maintained by Rico Sta. Cruz with help from contributors ([list][contributors]).
+> **mocha-jsdom** © 2014-2018 Rico Sta. Cruz. Released under the [MIT] License.<br>
+> Authored and maintained by Rico Sta. Cruz with help from contributors ([list][contributors]).
 
-> [ricostacruz.com](http://ricostacruz.com) &nbsp;&middot;&nbsp;
-> GitHub [@rstacruz](https://github.com/rstacruz) &nbsp;&middot;&nbsp;
-> Twitter [@rstacruz](https://twitter.com/rstacruz)
+[![](https://img.shields.io/github/followers/rstacruz.svg?style=social&label=@rstacruz)](https://github.com/rstacruz)
+&nbsp;&nbsp;
+[![](https://img.shields.io/twitter/follow/rstacruz.svg?style=social&label=@rstacruz)](https://twitter.com/rstacruz)
+&nbsp;&nbsp;
+**[ricostacruz.com](http://ricostacruz.com)**
 
-[MIT]: http://mit-license.org/
+[mit]: http://mit-license.org/
 [contributors]: http://github.com/rstacruz/mocha-jsdom/contributors

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ See [examples/basic](examples/basic) for an example of a basic setup.
 
 <br>
 
+## Upgrading to v2.0.0
+
+If you are coming from mocha-jsdom v1.x, remove `jsdom` if you're not using it before upgrading. `jsdom` is now a direct dependency of `mocha-jsdom`.
+
+```bash
+# using Yarn
+yarn remove jsdom
+yarn upgrade mocha-jsdom
+```
+
+```bash
+# using npm
+npm uninstall -S -D jsdom
+npm upgrade mocha-jsdom
+```
+
+<br>
+
 ## Node and io.js information
 
 As of jsdom 4.0.0, [jsdom now requires io.js](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400) and will not work with Node.js 0.12 or below.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "chai": "4.1.2",
     "istanbul": "0.4.5",
     "jquery": "3.3.1",
-    "jsdom": "~11.11.0",
     "mocha": "5.2.0",
     "mocha-standard": "1.0.0",
     "standard": "11.0.1"
@@ -26,7 +25,6 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "jsdom": ">10.0.0",
     "mocha": "*"
   },
   "repository": {
@@ -37,5 +35,8 @@
     "coverage": "istanbul cover _mocha -- -R spec",
     "test": "mocha"
   },
-  "browser": "browser.js"
+  "browser": "browser.js",
+  "dependencies": {
+    "jsdom": "^11.11.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,7 +1067,7 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@~11.11.0:
+jsdom@^11.11.0:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
   dependencies:


### PR DESCRIPTION
jsdom is now a direct dependency of mocha-jsdom! This is a breaking change that will be released as v2.0.0.