### PR TITLE
Fix SecurityError: localStorage is not available

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ blacklist.push('constructor')
  * default config
  */
 
-var defaults = {,
+var defaults = {
   url: 'http://localhost',
   globalize: true,
   console: true,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ blacklist.push('constructor')
  * default config
  */
 
-var defaults = {
+var defaults = {,
+  url: 'http://localhost',
   globalize: true,
   console: true,
   useEach: false,


### PR DESCRIPTION
There was an error popping up...
```
SecurityError: localStorage is not available for opaque origins
```

Adding a "url" option to the defaults fixes the issue.

See https://github.com/jsdom/jsdom/issues/2304